### PR TITLE
Fix kernel version parsing in /boot/changes.txt for 6.10.0

### DIFF
--- a/plugin_update_helper
+++ b/plugin_update_helper
@@ -26,7 +26,7 @@ do
   CUR_KERNEL_V="$(uname -r)"
   NEW_KERNEL_V="$(grep -E -A2 "Linux kernel" /boot/changes.txt | grep -E "version" | awk '{print $3}' | sort -V | tail -1)-Unraid"
   if [ "${NEW_KERNEL_V}" == "-Unraid" ]; then
-    NEW_KERNEL_V="$(grep -E -A2 "Linux kernel" /boot/changes.txt | grep -E "Unraid" | awk '{print $3}' | sort -V | tail -1)"
+    NEW_KERNEL_V="$(grep -E -A2 "Linux kernel" /boot/changes.txt | grep -E "Unraid" | awk '{print $2}' | sort -V | tail -1)"
   fi
   if [ -z "${NEW_KERNEL_V}" ]; then
     /usr/local/emhttp/plugins/dynamix/scripts/notify -e "Plugin Update Helper" -d "Something went horrybly wrong, can't fetch new unRAID Kernel version, please reboot your Server and make sure that you have a active Internet connection on boot without any AdBlocking softwar infront of it!"  -i "alert"

--- a/plugin_update_helper
+++ b/plugin_update_helper
@@ -1,5 +1,5 @@
 # Plugin Update Helper by ich777 for unRAID
-# Plugin-Update-Helper version: 2022.05.06
+# Plugin-Update-Helper version: 2022.05.18
 #
 # Currently supported Plugins:
 # AMD-Vendor-Reset: https://github.com/ich777/unraid-amd-vendor-reset


### PR DESCRIPTION
Fix unRAID Kernel version parsing in Plugin Update Helper Script

See the following comment for more details:
https://forums.unraid.net/bug-reports/stable-releases/692-upgrading-to-6100-plugin-update-helper-hangs-r1903/?do=findComment&comment=19164